### PR TITLE
Update Cargo.toml dependency wasm-bindgen to avoid proc_macro err

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Nick Fitzgerald <fitzgen@gmail.com>"]
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen = "0.2.8"
+wasm-bindgen = "0.2.11"
 
 [profile.release]
 # Include function names in the `.wasm` for better debugging and


### PR DESCRIPTION
Very minor pull.

After meeting Nick and Jim at the office I went out to try this workshop on my own but wound up with the error attached below. The solution seems to be a newer version of wasm-bindgen that has the correct enum variations for TokenTree within  proc_macro. Cheers!  

```

error[E0433]: failed to resolve. Could not find `Op` in `proc_macro`
  --> /home/me/.cargo/registry/src/github.com-1ecc6299db9ec823/proc-macro2-0.3.6/src/unstable.rs:72:42
   |
72 |                 let mut op = proc_macro::Op::new(tt.op(), spacing);
   |                                          ^^ Could not find `Op` in `proc_macro`

error[E0433]: failed to resolve. Could not find `Term` in `proc_macro`
   --> /home/me/.cargo/registry/src/github.com-1ecc6299db9ec823/proc-macro2-0.3.6/src/unstable.rs:279:31
    |
279 |             term: proc_macro::Term::new(string, span.0),
    |                               ^^^^ Could not find `Term` in `proc_macro`

error[E0412]: cannot find type `Term` in module `proc_macro`
   --> /home/me/.cargo/registry/src/github.com-1ecc6299db9ec823/proc-macro2-0.3.6/src/unstable.rs:273:23
    |
273 |     term: proc_macro::Term,
    |                       ^^^^ not found in `proc_macro`
help: possible candidates are found in other modules, you can import them into scope
    |
3   | use Term;
    |
3   | use imp::Term;
    |

error[E0599]: no function or associated item named `empty` found for type `proc_macro::TokenStream` in the current scope
  --> /home/me/.cargo/registry/src/github.com-1ecc6299db9ec823/proc-macro2-0.3.6/src/unstable.rs:18:21
   |
18 |         TokenStream(proc_macro::TokenStream::empty())
   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function or associated item not found in `proc_macro::TokenStream`

error[E0599]: no variant named `Op` found for type `proc_macro::TokenTree` in the current scope
   --> /home/me/.cargo/registry/src/github.com-1ecc6299db9ec823/proc-macro2-0.3.6/src/unstable.rs:132:13
    |
132 |             proc_macro::TokenTree::Op(tt) => {
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ variant not found in `proc_macro::TokenTree`

error[E0599]: no variant named `Term` found for type `proc_macro::TokenTree` in the current scope
   --> /home/me/.cargo/registry/src/github.com-1ecc6299db9ec823/proc-macro2-0.3.6/src/unstable.rs:141:13
    |
141 |             proc_macro::TokenTree::Term(s) => {
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ variant not found in `proc_macro::TokenTree`

error: aborting due to 6 previous errors

Some errors occurred: E0412, E0433, E0599.
For more information about an error, try `rustc --explain E0412`.
error: Could not compile `proc-macro2`.
warning: build failed, waiting for other jobs to finish...
error: build failed
npm ERR! code ELIFECYCLE
npm ERR! errno 101
npm ERR! @ build-debug: `cargo +nightly build --target wasm32-unknown-unknown && wasm-bindgen target/wasm32-unknown-unknown/debug/hello_world.wasm --o
ut-dir .`
npm ERR! Exit status 101
npm ERR!
npm ERR! Failed at the @ build-debug script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/me/.npm/_logs/2018-06-11T21_20_56_912Z-debug.log

```